### PR TITLE
Add explicit return to avoid implicit None return which doesn't

### DIFF
--- a/adafruit_irremote.py
+++ b/adafruit_irremote.py
@@ -179,6 +179,7 @@ class GenericDecode:
                     else:
                         return received
                 received.append(pulse)
+        return received
 
 class GenericTransmit:
     """Generic infrared transmit class that handles encoding."""


### PR DESCRIPTION
match the expression return within the loop.