### PR TITLE
improve read_pulses/blocking reliability

### DIFF
--- a/adafruit_irremote.py
+++ b/adafruit_irremote.py
@@ -193,7 +193,7 @@ class GenericDecode:
                 output[i // 8] |= 1
         return output
 
-    def read_pulses_non_blocking(self, input_pulses, max_pulse=10000, pulse_window=0.10):
+    def _read_pulses_non_blocking(self, input_pulses, max_pulse=10000, pulse_window=0.10):
         """Read out a burst of pulses without blocking until pulses stop for a specified
             period (pulse_window), pruning pulses after a pulse longer than ``max_pulse``.
 
@@ -237,7 +237,7 @@ class GenericDecode:
             :param float blocking_delay: delay between pulse checks when blocking
            """
         while True:
-            pulses = self.read_pulses_non_blocking(input_pulses, max_pulse, pulse_window)
+            pulses = self._read_pulses_non_blocking(input_pulses, max_pulse, pulse_window)
             if blocking and pulses is None:
                 time.sleep(blocking_delay)
                 continue

--- a/adafruit_irremote.py
+++ b/adafruit_irremote.py
@@ -73,6 +73,7 @@ Implementation Notes
 # pylint: disable=no-self-use
 
 import array
+import time
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_IRRemote.git"
@@ -192,30 +193,56 @@ class GenericDecode:
                 output[i // 8] |= 1
         return output
 
-    def read_pulses(self, input_pulses, max_pulse=10000, blocking=True):
-        """Read out a burst of pulses until a pulse is longer than ``max_pulse``.
+    def read_pulses_non_blocking(self, input_pulses, max_pulse=10000, pulse_window=0.10):
+        """Read out a burst of pulses without blocking until pulses stop for a specified
+            period (pulse_window), pruning pulses after a pulse longer than ``max_pulse``.
 
-           :param ~pulseio.PulseIn input_pulses: Object to read pulses from
-           :param int max_pulse: Pulse duration to end a burst
-           :param bool blocking: If True, will block until pulses found.
-               If False, will return None if no pulses.
-               Defaults to True for backwards compatibility
+            :param ~pulseio.PulseIn input_pulses: Object to read pulses from
+            :param int max_pulse: Pulse duration to end a burst
+            :param float pulse_window: pulses are collected for this period of time
            """
-        if not input_pulses and not blocking:
-            return None
-        received = []
+        received = None
+        recent_count = 0
+        pruning = False
         while True:
-            while not input_pulses:
-                pass
-            while input_pulses:
+            try:
                 pulse = input_pulses.popleft()
+                recent_count += 1
                 if pulse > max_pulse:
-                    if not received:
+                    if received is None:
                         continue
-                    else:
-                        return received
-                received.append(pulse)
-        return received
+                    pruning = True
+                if not pruning:
+                    if received is None:
+                        received = []
+                    received.append(pulse)
+            except IndexError:
+                if recent_count == 0:
+                    return received
+                recent_count = 0
+                time.sleep(pulse_window)
+
+    # pylint: disable-msg=too-many-arguments
+    def read_pulses(self, input_pulses, max_pulse=10000, blocking=True,
+                    pulse_window=0.10, blocking_delay=0.10):
+        """Read out a burst of pulses until pulses stop for a specified
+            period (pulse_window), pruning pulses after a pulse longer than ``max_pulse``.
+
+            :param ~pulseio.PulseIn input_pulses: Object to read pulses from
+            :param int max_pulse: Pulse duration to end a burst
+            :param bool blocking: If True, will block until pulses found.
+                If False, will return None if no pulses.
+                Defaults to True for backwards compatibility
+            :param float pulse_window: pulses are collected for this period of time
+            :param float blocking_delay: delay between pulse checks when blocking
+           """
+        while True:
+            pulses = self.read_pulses_non_blocking(input_pulses, max_pulse, pulse_window)
+            if blocking and pulses is None:
+                time.sleep(blocking_delay)
+                continue
+            return pulses
+    # pylint: enable-msg=too-many-arguments
 
 class GenericTransmit:
     """Generic infrared transmit class that handles encoding."""

--- a/adafruit_irremote.py
+++ b/adafruit_irremote.py
@@ -205,7 +205,7 @@ class GenericDecode:
         recent_count = 0
         pruning = False
         while True:
-            try:
+            while input_pulses:
                 pulse = input_pulses.popleft()
                 recent_count += 1
                 if pulse > max_pulse:
@@ -216,11 +216,11 @@ class GenericDecode:
                     if received is None:
                         received = []
                     received.append(pulse)
-            except IndexError:
-                if recent_count == 0:
-                    return received
-                recent_count = 0
-                time.sleep(pulse_window)
+
+            if recent_count == 0:
+                return received
+            recent_count = 0
+            time.sleep(pulse_window)
 
     # pylint: disable-msg=too-many-arguments
     def read_pulses(self, input_pulses, max_pulse=10000, blocking=True,

--- a/adafruit_irremote.py
+++ b/adafruit_irremote.py
@@ -222,8 +222,7 @@ class GenericDecode:
             recent_count = 0
             time.sleep(pulse_window)
 
-    # pylint: disable-msg=too-many-arguments
-    def read_pulses(self, input_pulses, max_pulse=10000, blocking=True,
+    def read_pulses(self, input_pulses, *, max_pulse=10000, blocking=True,
                     pulse_window=0.10, blocking_delay=0.10):
         """Read out a burst of pulses until pulses stop for a specified
             period (pulse_window), pruning pulses after a pulse longer than ``max_pulse``.
@@ -242,7 +241,6 @@ class GenericDecode:
                 time.sleep(blocking_delay)
                 continue
             return pulses
-    # pylint: enable-msg=too-many-arguments
 
 class GenericTransmit:
     """Generic infrared transmit class that handles encoding."""


### PR DESCRIPTION
This is a rewrite of the read_pulses method in an attempt to improve reliability and fully implement blocking/non-blocking behavior.

The read_pulses_non_blocking() method reads pulses without blocking and read_pulses() repeatedly calls the non-blocking method with a short delay specified between calls.

A new parameter is introduced with both methods named "pulse_window". It specifies the amount of time to collect a group of pulses to try to keep from getting partial results. The default value is 0.1 seconds.

Another new parameter named "blocking_delay" is introduced for read_pulses() for use when blocking. When blocking, repeated calls are made to read_pulses_non_blocking() until pulses are received. Between each call, time.sleep is used using blocking_delay. The default value is 0.1 seconds.