### PR TITLE
Brought docs example into parity with actual example, removed unused code lines.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Usage Example
         pulses = decoder.read_pulses(pulsein)
         print("Heard", len(pulses), "Pulses:", pulses)
         try:
-            code = decoder.decode_bits(pulses, debug=False)
+            code = decoder.decode_bits(pulses)
             print("Decoded:", code)
         except adafruit_irremote.IRNECRepeatException:  # unusual short code!
             print("NEC repeat!")

--- a/README.rst
+++ b/README.rst
@@ -67,11 +67,10 @@ Usage Example
     import pulseio
     import board
     import adafruit_irremote
+
     pulsein = pulseio.PulseIn(board.REMOTEIN, maxlen=120, idle_state=True)
     decoder = adafruit_irremote.GenericDecode()
 
-    # size must match what you are decoding! for NEC use 4
-    received_code = bytearray(4)
 
     while True:
         pulses = decoder.read_pulses(pulsein)

--- a/adafruit_irremote.py
+++ b/adafruit_irremote.py
@@ -32,11 +32,10 @@ Demo code for Circuit Playground Express:
     import pulseio
     import board
     import adafruit_irremote
+
     pulsein = pulseio.PulseIn(board.REMOTEIN, maxlen=120, idle_state=True)
     decoder = adafruit_irremote.GenericDecode()
 
-    # size must match what you are decoding! for NEC use 4
-    received_code = bytearray(4)
 
     while True:
         pulses = decoder.read_pulses(pulsein)

--- a/examples/irremote_simpletest.py
+++ b/examples/irremote_simpletest.py
@@ -3,11 +3,10 @@
 import pulseio
 import board
 import adafruit_irremote
+
 pulsein = pulseio.PulseIn(board.REMOTEIN, maxlen=120, idle_state=True)
 decoder = adafruit_irremote.GenericDecode()
 
-# size must match what you are decoding! for NEC use 4
-received_code = bytearray(4)
 
 while True:
     pulses = decoder.read_pulses(pulsein)


### PR DESCRIPTION
The example files themselves work, but if one copied the code from README.rst, it would crash. This brings the docs to be the same as the actual code provided.

Also, I removed some python that wasn't actually doing anything, and thus might confuse people.