### PR TITLE
[RFC] Add support for decoding SIRC (Sony) protocol.

### DIFF
--- a/adafruit_irremote.py
+++ b/adafruit_irremote.py
@@ -86,6 +86,15 @@ class IRNECRepeatException(Exception):
     """Exception when a NEC repeat is decoded"""
 
 
+def _bits_to_value_lsb(bits):
+    result = 0
+
+    for position, value in enumerate(bits):
+        result += value << position
+
+    return result
+
+
 class GenericDecode:
     """Generic decoding of infrared signals"""
 
@@ -110,6 +119,59 @@ class GenericDecode:
                 bins.append([pulse, 1])
             # print(bins)
         return bins
+
+    def decode_sirc(self, pulses):
+        """Decode SIRC (Sony) protocol commands from raw pulses.
+
+        The Sony command protocol uses a different format than the normal RC-5,
+        which requires a different decoding scheme.
+
+        Details of the protocol can be found at:
+
+        https://www.sbprojects.net/knowledge/ir/sirc.php
+        http://www.righto.com/2010/03/understanding-sony-ir-remote-codes-lirc.html
+        """
+
+        # SIRC supports 12-, 15- and 20-bit commands. There's always one header pulse,
+        # and then two pulses per bit, so accept 25-, 31- and 41-pulses commands.
+        if not len(pulses) in [25, 31, 41]:
+            raise IRDecodeException("Invalid number of pulses %d" % len(pulses))
+
+        if not 2200 <= pulses[0] <= 2600:
+            raise IRDecodeException("Invalid header pulse length (%d usec)" % pulses[0])
+
+        evens = pulses[1::2]
+        odds = pulses[2::2]
+        pairs = zip(evens, odds)
+        bits = []
+        for even, odd in pairs:
+            if odd > even * 1.75:
+                bits.append(1)
+            else:
+                bits.append(0)
+
+        command_bits = bits[0:7]
+
+        # 20-bit commands are the same as 12-bit but with an additional 8-bit
+        # extension. 15-bit commands use 8-bit for the device address instead.
+        if len(pulses) == 31:
+            device_bits = bits[7:15]
+            extended_bits = None
+        else:
+            device_bits = bits[7:12]
+            extended_bits = bits[12:]
+
+        command = _bits_to_value_lsb(command_bits)
+        device = _bits_to_value_lsb(device_bits)
+        if extended_bits:
+            extended = _bits_to_value_lsb(extended_bits)
+        else:
+            extended = None
+
+        if extended is None:
+            return [command, device]
+
+        return [command, device, extended]
 
     def decode_bits(self, pulses):
         """Decode the pulses into bits."""

--- a/adafruit_irremote.py
+++ b/adafruit_irremote.py
@@ -189,13 +189,15 @@ class GenericDecode:
         if len(pulses) < 10:
             raise IRDecodeException("10 pulses minimum")
 
-        # remove any header
-        del pulses[0]
-        if len(pulses) % 2 == 1:
-            del pulses[0]
+        # Ignore any header (evens start at 1), and any trailer.
+        if len(pulses) % 2 == 0:
+            pulses_end = -1
+        else:
+            pulses_end = None
 
-        evens = pulses[0::2]
-        odds = pulses[1::2]
+        evens = pulses[1:pulses_end:2]
+        odds = pulses[2:pulses_end:2]
+
         # bin both halves
         even_bins = self.bin_data(evens)
         odd_bins = self.bin_data(odds)


### PR DESCRIPTION
This requires a slightly different implementation of the pulse decoding to
make sense of the commands.

The mark/space coding might actually be the same between the two and I'm
not sure what's the best choice to implement this, between the binning and
the guessing.

Note that with this code in, adafruit_irremote.py needs to be compiled to
mpy for the Adafruit Feather M0 to be able to load.

---

In addition to the notes above — I'm not sure about the structure of the code.

Should the SIRC decoder be a separate module, to avoid the RAM issue? Should it similarly include the transmitter (which I want to write but I haven't written yet, also because I don't have an emitter at hand until tomorrow)?