### PR TITLE
Implement nonblocking decoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ bundles
 .eggs
 dist
 **/*.egg-info
+*.swp

--- a/adafruit_irremote.py
+++ b/adafruit_irremote.py
@@ -254,11 +254,11 @@ class GenericDecode:
     # this here for back-compat, hence we disable pylint for that specific
     # complaint.
 
-    def bin_data(self, pulses):  # pylint: disable=R0201
+    def bin_data(self, pulses):  # pylint: disable=no-self-use
         "Wraps the top-level function bin_data for backward-compatibility."
         return bin_data(pulses)
 
-    def decode_bits(self, pulses):  # pylint: disable=R0201
+    def decode_bits(self, pulses):  # pylint: disable=no-self-use
         "Wraps the top-level function decode_bits for backward-compatibility."
         result = decode_bits(pulses)
         if isinstance(result, NECRepeatIRMessage):
@@ -268,7 +268,7 @@ class GenericDecode:
 
     def _read_pulses_non_blocking(
         self, input_pulses, max_pulse=10000, pulse_window=0.10
-    ):  # pylint: disable=R0201
+    ):  # pylint: disable=no-self-use
         """Read out a burst of pulses without blocking until pulses stop for a specified
         period (pulse_window), pruning pulses after a pulse longer than ``max_pulse``.
 

--- a/adafruit_irremote.py
+++ b/adafruit_irremote.py
@@ -196,8 +196,7 @@ class NonblockingGenericDecode:
     Decode pulses into bytes in a non-blocking fashion.
 
     :param ~pulseio.PulseIn input_pulses: Object to read pulses from
-    :param int max_pulse: Pulse duration to end a burst.  Units are
-    microseconds.
+    :param int max_pulse: Pulse duration to end a burst.  Units are microseconds.
 
     >>> pulses = PulseIn(...)
     >>> decoder = NonblockingGenericDecoder(pulses)

--- a/examples/irremote_nonblocking.py
+++ b/examples/irremote_nonblocking.py
@@ -3,10 +3,11 @@
 
 # Circuit Playground Express Demo Code
 # Adjust the pulseio 'board.PIN' if using something else
-import pulseio
-import board
-import adafruit_irremote
 import time
+
+import adafruit_irremote
+import board
+import pulseio
 
 pulsein = pulseio.PulseIn(board.REMOTEIN, maxlen=120, idle_state=True)
 decoder = adafruit_irremote.NonblockingGenericDecode(pulsein)

--- a/examples/irremote_nonblocking.py
+++ b/examples/irremote_nonblocking.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+# Circuit Playground Express Demo Code
+# Adjust the pulseio 'board.PIN' if using something else
+import pulseio
+import board
+import adafruit_irremote
+import time
+
+pulsein = pulseio.PulseIn(board.REMOTEIN, maxlen=120, idle_state=True)
+decoder = adafruit_irremote.NonblockingGenericDecode(pulsein)
+
+
+t0 = next_heartbeat = time.monotonic()
+
+while True:
+    for message in decoder.read():
+        print(f"t={time.monotonic() - t0:.3} New Message")
+        print("Heard", len(message.pulses), "Pulses:", message.pulses)
+        if isinstance(message, adafruit_irremote.IRMessage):
+            print("Decoded:", message.code)
+        elif isinstance(message, adafruit_irremote.NECRepeatIRMessage):
+            print("NEC repeat!")
+        elif isinstance(message, adafruit_irremote.UnparseableIRMessage):
+            print("Failed to decode", message.reason)
+        print("----------------------------")
+
+    # This heartbeat confirms that we are not blocked somewhere above.
+    t = time.monotonic()
+    if t > next_heartbeat:
+        print(f"t={time.monotonic() - t0:.3} Heartbeat")
+        next_heartbeat = t + 0.1

--- a/examples/irremote_nonblocking.py
+++ b/examples/irremote_nonblocking.py
@@ -5,9 +5,10 @@
 # Adjust the pulseio 'board.PIN' if using something else
 import time
 
-import adafruit_irremote
 import board
 import pulseio
+
+import adafruit_irremote
 
 pulsein = pulseio.PulseIn(board.REMOTEIN, maxlen=120, idle_state=True)
 decoder = adafruit_irremote.NonblockingGenericDecode(pulsein)


### PR DESCRIPTION
Thanks for maintaining this excellent ecosystem of software and hardware. This is my first attempt to contribute to an Adafruit repository.

## The Problem

As described in #32, the non-blocking code path in `GenericDecoder` is not really non-blocking. Several people have reproduced the issue: if you hold down a button on a remote control to produce a steady stream of pulses, `GenericDecoder.read_pulses(..., blocking=False)` blocks indefinitely until the pulse stream stops.

There is also a more subtle issue in the design. When the application is juggling multiple tasks, it's possible for more than one message to accumulate in `PulseIn` before we get around to reading it. But (if I understand correctly) the current `GenericDecoder` API has no way to return more than one code when it is read.

## Background

I am new to IR, but I wrote [`caproto`, a beginner-friendly library that solves similar problems](https://caproto.github.io/caproto) for EPICS, an industrial and scientific control protocol used by US Department of Enengy facilities and others. In this PR, I have tried to apply what I learned from that work about non-blocking message-parsing code, while taking as a light a touch as I can and carefully maintaining backward-compatibility with existing APIs.

## Proposed Solution

I cannot see how to fix the `GenericDecoder` in a backward-compatible way, so I have created a new class `NonblockingGenericDecoder`. This is a usage example:

```py
pulses = PulseIn(...)
decoder = NonblockingGenericDecoder(pulses)
while True:
    for message in decoder.read():
        if isinstance(message, IRMessage):
            message.code  # TA-DA! Do something with this in your application.
        else:
            # message is either NECRepeatIRMessage or
            # UnparseableIRMessage. You may decide to ignore it, raise
            # an error, or log the issue to a file. If you raise or log,
            # it may be helpful to include message.pulses in the error message.
        # There may be more messages left in the PulseIn, but we can
        # go do other stuff in the appliacation before parsing them if we want
        # before getting the next message.
    # No more messages left for now. We are caught up.
    # Do other stuff in your application and check back later.
```

Notes on the design:
* `decoder.read()` is a generator: it returns an iterator that you can loop over to get messages. This allows for the possibility that multiple messages accumulate between reads. When there are no messages, `decoder.read()` is simply an empty iterator.
* If there are some pulses in `PulseIn` but they happen to be part-way through a message when we `read()`, those pulses are stashed internally by `NonblockingGenericDecoder` and held until `read()` is called again and the message is completed.
* The `PulseIn` wouldn't necessary have to be an argument passed to `__init__`. It could be passed to `read()`, more akin to how it's done in `GenericDecoder`. But since we need a class anyway to store the partial message state, it seems convenient to pass `PulseIn` in the `__init__` so we only have to do it once. Also, since the decoder _consumes_ messages from `PulseIn`, mutating it by `popleft()`-ing contents off of it, it "owns" it in a sense. Thus, having it _belong_ to `NonblockingGenericDecoder` feels cleaner to me than passing it in to `read(pulses)` as a method argument.
* I have refactored `bin_data` and `decode_bits` from methods to functions so that they can be shared between `GenericDecoder` and `NonblockingGenericDecoder`. I noticed the comment that these are methods because "we may add object level config later". I suggest that config could be passed in as a parameter without making these into methods. They would only need to be methods if they need to _modify_ instance state. I don't think that should come up, so I think it is safe to make them simple functions.
* I have added some new ~classes~ `namedtuple` types (`IRMessage` and friends) to do the job that `GenericDecoder` does with exceptions. That is, the `try`/`except` control flow is replaced by `if isinstance(...)` control flow. There are couple reasons for this.
  * When we change from returning a single code to returning an iterable of potentially _multiple_ codes, the exception raising becomes a hassle. When a bad message is raised, we have catch it and then start reading again.
  * Even when parsing succeeds, it's convenient to have this `IRMessage` object bundling together the `code` _and_ the `pulses` in case we want to do something with the pulses. (In caproto, we get a lot of use out of similar objects which contain both human-friendly properties and the raw bytes received.)
  * Exception throwing is not a cheap operation in Python. Since repeat codes and unparseable messages are not especially rare or unexpected in IR, using exceptions to represent them may lead to excess stack-thrashing in the interpreter that puts a burden on the application.

## Evidence that it works smoothly

Performing the same [test that I performed in #32](https://github.com/adafruit/Adafruit_CircuitPython_IRRemote/issues/32#issuecomment-764535729) with this new API, messages are parsed quickly and the application loop is given frequent opportunity to do other work, as in indicated by the "Heartbeat" messages.

```
t=0.715 Heartbeat
t=0.742 New Message
Heard 42 Pulses: (2429, 560, 1228, 563, 637, 557, 1229, 567, 1282, 507, 1232, 560, 1228, 581, 620, 558, 634, 559, 1277, 521, 632, 578, 1208, 597, 1236, 528, 678, 517, 1223, 562, 632, 563, 632, 568, 627, 565, 1227, 561, 1233, 559, 1236, 11702)
Decoded: [67, 75, 8]
----------------------------
t=0.789 New Message
Heard 42 Pulses: (2434, 555, 1231, 570, 630, 555, 1231, 567, 1225, 561, 1237, 554, 1232, 564, 667, 529, 684, 508, 1219, 582, 613, 585, 1218, 593, 1220, 536, 629, 565, 1230, 562, 632, 563, 628, 565, 628, 572, 1225, 561, 1225, 567, 1225, 11712)
Decoded: [67, 75, 8]
----------------------------
t=0.816 Heartbeat
t=0.832 New Message
Heard 42 Pulses: (2423, 568, 1224, 565, 629, 571, 1223, 563, 1232, 560, 1227, 574, 1218, 571, 632, 563, 623, 578, 1214, 582, 612, 599, 1195, 605, 1237, 543, 639, 526, 1226, 567, 634, 560, 634, 561, 686, 509, 1237, 553, 1227, 568, 1224, 11715)
Decoded: [67, 75, 8]
----------------------------
t=0.879 New Message
Heard 42 Pulses: (2420, 569, 1281, 506, 687, 507, 1233, 559, 1280, 512, 1228, 570, 1222, 564, 630, 575, 620, 572, 1278, 530, 606, 594, 1212, 549, 1253, 543, 642, 548, 1230, 567, 680, 510, 638, 556, 637, 556, 1284, 510, 1230, 559, 1232, 11706)
Decoded: [67, 75, 8]
----------------------------
t=0.93 New Message
Heard 42 Pulses: (2429, 560, 1235, 558, 634, 560, 1238, 554, 1284, 513, 1227, 561, 1233, 560, 705, 489, 633, 561, 1233, 584, 611, 573, 1223, 557, 1250, 543, 636, 590, 1197, 567, 627, 564, 637, 554, 640, 554, 1233, 563, 1229, 559, 1233, 11706)
Decoded: [67, 75, 8]
----------------------------
t=0.945 Heartbeat
t=0.969 New Message
Heard 42 Pulses: (2429, 561, 1283, 510, 690, 504, 1283, 509, 1230, 573, 1219, 562, 1283, 510, 632, 562, 632, 562, 1283, 510, 632, 562, 1235, 592, 1195, 573, 622, 592, 1199, 602, 610, 548, 666, 526, 655, 549, 1220, 596, 1196, 562, 1233, 11704)
Decoded: [67, 75, 8]
----------------------------
t=1.01 New Message
Heard 41 Pulses: (2428, 562, 1236, 556, 634, 560, 1236, 556, 1283, 515, 1225, 562, 1235, 556, 634, 560, 634, 591, 1206, 595, 652, 502, 1242, 550, 1254, 546, 629, 606, 1237, 507, 1200, 629, 563, 621, 569, 1286, 511, 1223, 564, 1238, 11698)
Failed to decode Both even/odd pulses differ

```

## Open questions

* I am not confident that I understand the purpose of the "pruning" code in `GenericDecoder`. Is that necessary because `GenericDecoder` can only return one `code` per read, and thus has to dump any pulses past the first code? Is it safe to assume that no pruning is needed in this new decoder that can yield multiple codes?
* What should we do with the broken code path `read_pulses(..., blocking=False)`? Should it raise an error pointing people to `GenericNonblockingDecoder`? Or issue a warning?