### PR TITLE
Fix adafruit_irremote.GenericDecode's decode() method to return decoded result

### DIFF
--- a/adafruit_irremote.py
+++ b/adafruit_irremote.py
@@ -265,6 +265,7 @@ class GenericDecode:
             raise IRNECRepeatException()
         if isinstance(result, UnparseableIRMessage):
             raise IRDecodeException("10 pulses minimum")
+        return result
 
     def _read_pulses_non_blocking(
         self, input_pulses, max_pulse=10000, pulse_window=0.10

--- a/adafruit_irremote.py
+++ b/adafruit_irremote.py
@@ -265,7 +265,7 @@ class GenericDecode:
             raise IRNECRepeatException()
         if isinstance(result, UnparseableIRMessage):
             raise IRDecodeException("10 pulses minimum")
-        return result
+        return result.code
 
     def _read_pulses_non_blocking(
         self, input_pulses, max_pulse=10000, pulse_window=0.10


### PR DESCRIPTION
Fix the decode_bits() method in the object wrapper to return the IRMessage returned by the decode_bits() function. Otherwise decoder.decode_bits() was returning None.

Fixes #47 
Fixes #52 
Fixes #48