### PR TITLE
Use PulseOut only; no PWMOut

### DIFF
--- a/examples/irremote_transmit.py
+++ b/examples/irremote_transmit.py
@@ -5,7 +5,6 @@
 # pylint: disable-msg=no-member
 import time
 import pulseio
-import pwmio
 import board
 import digitalio
 import adafruit_irremote
@@ -15,9 +14,8 @@ button = digitalio.DigitalInOut(board.D4)
 button.direction = digitalio.Direction.INPUT
 button.pull = digitalio.Pull.DOWN
 
-# Create a 'pwmio' output, to send infrared signals on the IR transmitter @ 38KHz
-pwm = pwmio.PWMOut(board.IR_TX, frequency=38000, duty_cycle=2**15)
-pulseout = pulseio.PulseOut(pwm)
+# Create a 'PulseOut' to send infrared signals on the IR transmitter @ 38KHz
+pulseout = pulseio.PulseOut(board.IR_TX, frequency=38000, duty_cycle=2**15)
 # Create an encoder that will take numbers and turn them into NEC IR pulses
 encoder = adafruit_irremote.GenericTransmit(
     header=[9500, 4500], one=[550, 550], zero=[550, 1700], trail=0


### PR DESCRIPTION
As of CircuitPython 7, `PulseOut` using a `PWMOut` is deprecated. Instead you pass the pin directly. In Circuitpython 8, using a `PWMOut` will go away completely. So get ready for that.