### PR TITLE
Fix pylint errors

### DIFF
--- a/adafruit_irremote.py
+++ b/adafruit_irremote.py
@@ -235,7 +235,7 @@ class NonblockingGenericDecode:
                 except FailedToDecode as err:
                     # If you want to debug failed decodes, this would be a good
                     # place to print/log or (re-)raise.
-                    (unparseable_message,) = err.args
+                    unparseable_message = err.args[0]
                     yield unparseable_message
                 self._unparsed_pulses.clear()
                 # TODO Do we need to consume and throw away more pulses here?


### PR DESCRIPTION
Fixed the following `pylint` errors:

```
************* Module adafruit_irremote
Error: adafruit_irremote.py:238:20: W0632: Possible unbalanced tuple unpacking with sequence: left side has 1 label(s), right side has 0 value(s) (unbalanced-tuple-unpacking)
```