### PR TITLE
try including upgrade flag

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Unlicense
 
 sphinx>=4.0.0
-sphinx-rtd-theme
+sphinx-rtd-theme --install-option="--upgrade"


### PR DESCRIPTION
see if this will overwrite the version that RTD installs by default (`0.4.3`), shown in this build log: https://readthedocs.org/projects/adafruit-circuitpython-irremote/builds/19119043/