### PR TITLE
try pinning version?

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Unlicense
 
 sphinx>=4.0.0
-sphinx-rtd-theme --install-option="--upgrade"
+sphinx-rtd-theme==1.1.1


### PR DESCRIPTION
So far the RTD default version of `0.4.3` is taking precedent over the "latest version" that I attempted to declare in docs/requirements.txt because they do their hardcoded install first before running install on our requirements. 

So when it gets to installing from our file sphinx-rtd-theme is already installed and therefore it skips installing it again (also not upgrading it to the newer version).