### PR TITLE
Compatibility for NEC protocol is fixed

### DIFF
--- a/adafruit_irremote.py
+++ b/adafruit_irremote.py
@@ -353,10 +353,10 @@ class GenericTransmit:
         self,
         header: List[int],
         one: List[int],
-        zero: List[int], 
+        zero: List[int],
         trail: int,
         *,
-        debug: bool = False
+        debug: bool = False,
     ) -> None:
         self.header = header
         self.one = one
@@ -388,8 +388,8 @@ class GenericTransmit:
 
         durations = array.array(
             "H",
-            [0] 
-            * (len(self.header) + bits_to_send * 2 + (0 if self.trail is None else 1))
+            [0]
+            * (len(self.header) + bits_to_send * 2 + (0 if self.trail is None else 1)),
         )
 
         for i, _ in enumerate(self.header):

--- a/adafruit_irremote.py
+++ b/adafruit_irremote.py
@@ -350,7 +350,13 @@ class GenericTransmit:
     """
 
     def __init__(
-        self, header: List[int], one: List[int], zero: List[int], trail: int, *, debug: bool = False
+        self,
+        header: List[int],
+        one: List[int],
+        zero: List[int], 
+        trail: int,
+        *,
+        debug: bool = False
     ) -> None:
         self.header = header
         self.one = one
@@ -381,12 +387,14 @@ class GenericTransmit:
             bits_to_send = nbits
 
         durations = array.array(
-            "H", [0] * (len(self.header) + bits_to_send * 2 + (0 if self.trail is None else 1))
+            "H",
+            [0] 
+            * (len(self.header) + bits_to_send * 2 + (0 if self.trail is None else 1))
         )
-        
+
         for i, _ in enumerate(self.header):
             durations[i] = self.header[i]
-    
+
         if self.trail is not None:
             durations[-1] = self.trail
         out = len(self.header)

--- a/examples/irremote_transmit.py
+++ b/examples/irremote_transmit.py
@@ -18,7 +18,7 @@ button.pull = digitalio.Pull.DOWN
 pulseout = pulseio.PulseOut(board.IR_TX, frequency=38000, duty_cycle=2**15)
 # Create an encoder that will take numbers and turn them into NEC IR pulses
 encoder = adafruit_irremote.GenericTransmit(
-    header=[9500, 4500], one=[550, 550], zero=[550, 1700], trail=0
+    header=[9000, 4500], one=[560, 1700], zero=[560, 1700], trail=560
 )
 
 while True:


### PR DESCRIPTION
This PR fix #40, #39, #65  and enhance one.

First of all, the IR protocol used primarily in the world is the NEC protocol. The code in this repository was also inferred to assume the NEC protocol from the code comments.

#40 is a sample issue, so I have adapted to the NEC protocol.
#39 may also be a sample issue, I added the value instead of 0 because the NEC protocol requires an trail.

**examples/irremote_transmit.py**
```
    header=[9000, 4500], one=[560, 1700], zero=[560, 1700], trail=560
```

At the same time, decoding was adapted to the NEC protocol. This is a destructive change, but if this is not done, the RX/TX will not be consistent.

**adafruit_irremote.py**
```
        if (space * 0.75) <= pulse_length <= (space * 1.25):
            pulses[i] = True
        elif (mark * 0.75) <= pulse_length <= (mark * 1.25):
            pulses[i] = False
```

#65 is simply a typing change.

**adafruit_irremote.py**
```
    :param List[int] header: The length of header in microseconds, the length should be even
    :param List[int] one: The length of a one in microseconds
    :param List[int] zero: The length of a zero in microseconds
```

And the following is enhancement. The header is now variable instead of 2 fixed. This is useful for protocols that require a leader mark in addition to the header (e.g., Hitachi remote controls).

**adafruit_irremote.py**
```
        durations = array.array(
            "H", [0] * (len(self.header) + bits_to_send * 2 + (0 if self.trail is None else 1))
        )
        
        for i, _ in enumerate(self.header):
            durations[i] = self.header[i]
```

Please review and merge.
Because of the disruptive changes, a major version update would be desirable.